### PR TITLE
Give access to body set in broad phase filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ lto = true
 codegen-units = 1
 
 [patch.crates-io]
-ncollide2d = { path = "../ncollide/build/ncollide2d" }
-ncollide3d = { path = "../ncollide/build/ncollide3d" }
-kiss3d = { path = "../kiss3d" }
+#ncollide2d = { path = "../ncollide/build/ncollide2d" }
+#ncollide3d = { path = "../ncollide/build/ncollide3d" }
+#kiss3d = { path = "../kiss3d" }
 nphysics2d = { path = "build/nphysics2d" }
 nphysics3d = { path = "build/nphysics3d" }
 #simba = { path = "../simba" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ lto = true
 codegen-units = 1
 
 [patch.crates-io]
-#ncollide2d = { path = "../ncollide/build/ncollide2d" }
-#ncollide3d = { path = "../ncollide/build/ncollide3d" }
-#kiss3d = { path = "../kiss3d" }
+ncollide2d = { path = "../ncollide/build/ncollide2d" }
+ncollide3d = { path = "../ncollide/build/ncollide3d" }
+kiss3d = { path = "../kiss3d" }
 nphysics2d = { path = "build/nphysics2d" }
 nphysics3d = { path = "build/nphysics3d" }
 #simba = { path = "../simba" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ lto = true
 codegen-units = 1
 
 [patch.crates-io]
-ncollide2d = { path = "../ncollide/build/ncollide2d" }
-ncollide3d = { path = "../ncollide/build/ncollide3d" }
+#ncollide2d = { path = "../ncollide/build/ncollide2d" }
+#ncollide3d = { path = "../ncollide/build/ncollide3d" }
 #kiss3d = { path = "../kiss3d" }
 nphysics2d = { path = "build/nphysics2d" }
 nphysics3d = { path = "build/nphysics3d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ lto = true
 codegen-units = 1
 
 [patch.crates-io]
-#ncollide2d = { path = "../ncollide/build/ncollide2d" }
-#ncollide3d = { path = "../ncollide/build/ncollide3d" }
+ncollide2d = { path = "../ncollide/build/ncollide2d" }
+ncollide3d = { path = "../ncollide/build/ncollide3d" }
 #kiss3d = { path = "../kiss3d" }
 nphysics2d = { path = "build/nphysics2d" }
 nphysics3d = { path = "build/nphysics3d" }

--- a/build/nphysics2d/Cargo.toml
+++ b/build/nphysics2d/Cargo.toml
@@ -36,7 +36,7 @@ nalgebra   = { version = "0.22", features = [ "sparse" ] }
 approx     = "0.3"
 downcast-rs = "1"
 bitflags   = "1"
-ncollide2d = "0.24"
+ncollide2d = "0.25"
 instant    = { version = "0.1", features = [ "now" ]}
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/build/nphysics3d/Cargo.toml
+++ b/build/nphysics3d/Cargo.toml
@@ -37,7 +37,7 @@ nalgebra   = { version = "0.22", features = [ "sparse" ] }
 approx     = "0.3"
 downcast-rs = "1"
 bitflags   = "1"
-ncollide3d = "0.24"
+ncollide3d = "0.25"
 instant    = { version = "0.1", features = [ "now" ]}
 
 

--- a/build/nphysics_testbed2d/Cargo.toml
+++ b/build/nphysics_testbed2d/Cargo.toml
@@ -30,9 +30,9 @@ num-traits = "0.2"
 rand       = "0.7"
 instant    = { version = "0.1", features = [ "stdweb", "now" ]}
 simba      = "0.1"
-nalgebra   = "0.21"
-kiss3d     = { version = "0.24", features = [ "conrod" ] }
-ncollide2d = "0.23"
+nalgebra   = "0.22"
+kiss3d     = { version = "0.25", features = [ "conrod" ] }
+ncollide2d = "0.24"
 wrapped2d  = { version = "0.4", optional = true }
 salva2d = { version = "0.4", features = [ "nphysics" ], optional = true }
 

--- a/build/nphysics_testbed2d/Cargo.toml
+++ b/build/nphysics_testbed2d/Cargo.toml
@@ -31,8 +31,8 @@ rand       = "0.7"
 instant    = { version = "0.1", features = [ "stdweb", "now" ]}
 simba      = "0.1"
 nalgebra   = "0.22"
-kiss3d     = { version = "0.25", features = [ "conrod" ] }
-ncollide2d = "0.24"
+kiss3d     = { version = "0.26", features = [ "conrod" ] }
+ncollide2d = "0.25"
 wrapped2d  = { version = "0.4", optional = true }
 salva2d = { version = "0.4", features = [ "nphysics" ], optional = true }
 

--- a/build/nphysics_testbed3d/Cargo.toml
+++ b/build/nphysics_testbed3d/Cargo.toml
@@ -28,9 +28,9 @@ num-traits = "0.2"
 rand       = "0.7"
 instant    = { version = "0.1", features = [ "stdweb", "now" ]}
 simba      = "0.1"
-nalgebra   = "0.21"
-kiss3d     = { version = "0.24", features = [ "conrod" ] }
-ncollide3d = "0.23"
+nalgebra   = "0.22"
+kiss3d     = { version = "0.25", features = [ "conrod" ] }
+ncollide3d = "0.24"
 salva3d = { version = "0.4", features = [ "nphysics" ], optional = true }
 
 [dependencies.nphysics3d]

--- a/build/nphysics_testbed3d/Cargo.toml
+++ b/build/nphysics_testbed3d/Cargo.toml
@@ -29,8 +29,8 @@ rand       = "0.7"
 instant    = { version = "0.1", features = [ "stdweb", "now" ]}
 simba      = "0.1"
 nalgebra   = "0.22"
-kiss3d     = { version = "0.25", features = [ "conrod" ] }
-ncollide3d = "0.24"
+kiss3d     = { version = "0.26", features = [ "conrod" ] }
+ncollide3d = "0.25"
 salva3d = { version = "0.4", features = [ "nphysics" ], optional = true }
 
 [dependencies.nphysics3d]

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -12,7 +12,7 @@ improved_fixed_point_support = [ "nphysics2d/improved_fixed_point_support" ]
 rand       = "0.7"
 Inflector  = "0.11"
 nalgebra   = "0.22"
-ncollide2d = "0.24"
+ncollide2d = "0.25"
 simba      = { version = "0.1", features = [ "partial_fixed_point_support" ]}
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -11,8 +11,8 @@ improved_fixed_point_support = [ "nphysics2d/improved_fixed_point_support" ]
 [dependencies]
 rand       = "0.7"
 Inflector  = "0.11"
-nalgebra   = "0.21"
-ncollide2d = "0.23"
+nalgebra   = "0.22"
+ncollide2d = "0.24"
 simba      = { version = "0.1", features = [ "partial_fixed_point_support" ]}
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/examples2d/broad_phase_filter2.rs
+++ b/examples2d/broad_phase_filter2.rs
@@ -11,12 +11,12 @@ use nphysics2d::object::{
     DefaultBodyHandle, DefaultBodySet, DefaultColliderHandle, DefaultColliderSet, Ground,
     MultibodyDesc,
 };
-use nphysics2d::world::{BroadPhaseCollisionSet, DefaultGeometricalWorld, DefaultMechanicalWorld};
+use nphysics2d::world::{BroadPhasePairFilterSets, DefaultGeometricalWorld, DefaultMechanicalWorld};
 use nphysics_testbed2d::Testbed;
 
 struct NoMultibodySelfContactFilter;
 
-impl<N, Bodies, Colliders> BroadPhasePairFilter<N, BroadPhaseCollisionSet<'_, N, Bodies, Colliders>>
+impl<N, Bodies, Colliders> BroadPhasePairFilter<N, BroadPhasePairFilterSets<'_, N, Bodies, Colliders>>
     for NoMultibodySelfContactFilter
 where
     N: RealField,
@@ -27,7 +27,7 @@ where
         &self,
         h1: Colliders::Handle,
         h2: Colliders::Handle,
-        set: &BroadPhaseCollisionSet<'_, N, Bodies, Colliders>,
+        set: &BroadPhasePairFilterSets<'_, N, Bodies, Colliders>,
     ) -> bool {
         let a1 = set.colliders().get(h1).map(|c| c.anchor());
         let a2 = set.colliders().get(h2).map(|c| c.anchor());

--- a/examples2d/broad_phase_filter2.rs
+++ b/examples2d/broad_phase_filter2.rs
@@ -15,24 +15,20 @@ use nphysics_testbed2d::Testbed;
 
 struct NoMultibodySelfContactFilter;
 
-impl BroadPhasePairFilter<f32, Collider<f32, DefaultBodyHandle>, DefaultColliderHandle>
+impl BroadPhasePairFilter<f32, DefaultColliderSet<f32>>
     for NoMultibodySelfContactFilter
 {
     fn is_pair_valid(
         &self,
-        c1: &Collider<f32, DefaultBodyHandle>,
-        c2: &Collider<f32, DefaultBodyHandle>,
-        _: DefaultColliderHandle,
-        _: DefaultColliderHandle,
+        h1: DefaultColliderHandle,
+        h2: DefaultColliderHandle,
+        s: &DefaultColliderSet<f32>,
     ) -> bool {
-        match (c1.anchor(), c2.anchor()) {
+        let (c1, c2) = (s.get(h1), s.get(h2));
+        match (c1.map(|c| c.anchor()), c2.map(|c| c.anchor())) {
             (
-                ColliderAnchor::OnBodyPart {
-                    body_part: part1, ..
-                },
-                ColliderAnchor::OnBodyPart {
-                    body_part: part2, ..
-                },
+                Some(ColliderAnchor::OnBodyPart { body_part: part1, ..  }),
+                Some(ColliderAnchor::OnBodyPart { body_part: part2, ..  }),
             ) => part1.0 != part2.0, // Don't collide if the two parts belong to the same body.
             _ => true,
         }

--- a/examples2d/broad_phase_filter2.rs
+++ b/examples2d/broad_phase_filter2.rs
@@ -1,60 +1,71 @@
 extern crate nalgebra as na;
 
-use na::{Isometry2, Point2, Vector2};
+use na::{Isometry2, Point2, RealField, Vector2};
 use ncollide2d::broad_phase::BroadPhasePairFilter;
 use ncollide2d::shape::{Ball, Cuboid, ShapeHandle};
 use nphysics2d::force_generator::DefaultForceGeneratorSet;
 use nphysics2d::joint::DefaultJointConstraintSet;
 use nphysics2d::joint::{FreeJoint, RevoluteJoint};
 use nphysics2d::object::{
-    BodyPartHandle, Collider, ColliderAnchor, ColliderDesc, DefaultBodyHandle, DefaultBodySet,
-    DefaultColliderHandle, DefaultColliderSet, Ground, MultibodyDesc,
+    BodyPartHandle, BodySet, Collider, ColliderAnchor, ColliderDesc, ColliderSet,
+    DefaultBodyHandle, DefaultBodySet, DefaultColliderHandle, DefaultColliderSet, Ground,
+    MultibodyDesc,
 };
-use nphysics2d::world::{DefaultGeometricalWorld, DefaultMechanicalWorld};
+use nphysics2d::world::{BroadPhaseCollisionSet, DefaultGeometricalWorld, DefaultMechanicalWorld};
 use nphysics_testbed2d::Testbed;
 
 struct NoMultibodySelfContactFilter;
 
-impl BroadPhasePairFilter<f32, DefaultColliderSet<f32>>
+impl<N, Bodies, Colliders> BroadPhasePairFilter<N, BroadPhaseCollisionSet<'_, N, Bodies, Colliders>>
     for NoMultibodySelfContactFilter
+where
+    N: RealField,
+    Bodies: BodySet<N>,
+    Colliders: ColliderSet<N, Bodies::Handle>,
 {
     fn is_pair_valid(
         &self,
-        h1: DefaultColliderHandle,
-        h2: DefaultColliderHandle,
-        s: &DefaultColliderSet<f32>,
+        h1: Colliders::Handle,
+        h2: Colliders::Handle,
+        set: &BroadPhaseCollisionSet<'_, N, Bodies, Colliders>,
     ) -> bool {
-        let (c1, c2) = (s.get(h1), s.get(h2));
-        match (c1.map(|c| c.anchor()), c2.map(|c| c.anchor())) {
+        let a1 = set.colliders().get(h1).map(|c| c.anchor());
+        let a2 = set.colliders().get(h2).map(|c| c.anchor());
+
+        match (a1, a2) {
             (
-                Some(ColliderAnchor::OnBodyPart { body_part: part1, ..  }),
-                Some(ColliderAnchor::OnBodyPart { body_part: part2, ..  }),
+                Some(ColliderAnchor::OnBodyPart {
+                    body_part: part1, ..
+                }),
+                Some(ColliderAnchor::OnBodyPart {
+                    body_part: part2, ..
+                }),
             ) => part1.0 != part2.0, // Don't collide if the two parts belong to the same body.
             _ => true,
         }
     }
 }
 
-pub fn init_world(testbed: &mut Testbed) {
+/*
+ * NOTE: The `r` macro is only here to convert from f64 to the `N` scalar type.
+ * This simplifies experimentation with various scalar types (f32, fixed-point numbers, etc.)
+ */
+pub fn init_world<N: RealField>(testbed: &mut Testbed<N>) {
     /*
      * World
      */
-    let mechanical_world = DefaultMechanicalWorld::new(Vector2::new(0.0, -9.81));
-    let mut geometrical_world = DefaultGeometricalWorld::new();
+    let mechanical_world = DefaultMechanicalWorld::new(Vector2::new(r!(0.0), r!(-9.81)));
+    let geometrical_world = DefaultGeometricalWorld::new();
     let mut bodies = DefaultBodySet::new();
     let mut colliders = DefaultColliderSet::new();
     let joint_constraints = DefaultJointConstraintSet::new();
     let force_generators = DefaultForceGeneratorSet::new();
 
-    // Setup the custom broad-phase pair filter to prevent contacts between
-    // links belonging to the same multibody.
-    geometrical_world.set_broad_phase_pair_filter(NoMultibodySelfContactFilter);
-
     /*
      * Ground
      */
-    let ground_size = 25.0;
-    let ground_shape = ShapeHandle::new(Cuboid::new(Vector2::new(ground_size, 1.0)));
+    let ground_size = r!(25.0);
+    let ground_shape = ShapeHandle::new(Cuboid::new(Vector2::new(ground_size, r!(1.0))));
 
     let ground_handle = bodies.insert(Ground::new());
     let co = ColliderDesc::new(ground_shape)
@@ -71,6 +82,7 @@ pub fn init_world(testbed: &mut Testbed) {
      * Run the simulation.
      */
     testbed.set_ground_handle(Some(ground_handle));
+    testbed.set_broad_phase_pair_filter(NoMultibodySelfContactFilter);
     testbed.set_world(
         mechanical_world,
         geometrical_world,
@@ -82,14 +94,17 @@ pub fn init_world(testbed: &mut Testbed) {
     testbed.look_at(Point2::new(0.0, 5.0), 25.0);
 }
 
-fn build_ragdolls(bodies: &mut DefaultBodySet<f32>, colliders: &mut DefaultColliderSet<f32>) {
-    let body_rady = 1.2;
-    let body_radx = 0.2;
-    let head_rad = 0.4;
-    let member_rad = 0.1;
-    let arm_length = 0.9;
-    let leg_length = 1.4;
-    let space = 0.1;
+fn build_ragdolls<N: RealField>(
+    bodies: &mut DefaultBodySet<N>,
+    colliders: &mut DefaultColliderSet<N>,
+) {
+    let body_rady = r!(1.2);
+    let body_radx = r!(0.2);
+    let head_rad = r!(0.4);
+    let member_rad = r!(0.1);
+    let arm_length = r!(0.9);
+    let leg_length = r!(1.4);
+    let space = r!(0.1);
 
     let body_geom = ShapeHandle::new(Cuboid::new(Vector2::new(body_radx, body_rady)));
     let head_geom = ShapeHandle::new(Ball::new(head_rad));
@@ -105,48 +120,50 @@ fn build_ragdolls(bodies: &mut DefaultBodySet<f32>, colliders: &mut DefaultColli
     /*
      * Body.
      */
-    let body_collider = ColliderDesc::new(body_geom).density(0.3);
+    let body_collider = ColliderDesc::new(body_geom).density(r!(0.3));
     let mut body = MultibodyDesc::new(free);
 
     /*
      * Head.
      */
-    let head_collider = ColliderDesc::new(head_geom).density(0.3);
-    body.add_child(spherical)
-        .set_parent_shift(Vector2::new(0.0, body_rady + head_rad + space * 2.0));
+    let head_collider = ColliderDesc::new(head_geom).density(r!(0.3));
+    body.add_child(spherical).set_parent_shift(Vector2::new(
+        r!(0.0),
+        body_rady + head_rad + space * r!(2.0),
+    ));
 
     /*
      * Arms.
      */
-    let arm_collider = ColliderDesc::new(arm_geom).density(0.3);
+    let arm_collider = ColliderDesc::new(arm_geom).density(r!(0.3));
     body.add_child(spherical)
-        .set_parent_shift(Vector2::new(body_radx + 2.0 * space, body_rady))
-        .set_body_shift(Vector2::new(0.0, arm_length + space));
+        .set_parent_shift(Vector2::new(body_radx + r!(2.0) * space, body_rady))
+        .set_body_shift(Vector2::new(r!(0.0), arm_length + space));
 
     body.add_child(spherical)
-        .set_parent_shift(Vector2::new(-body_radx - 2.0 * space, body_rady))
-        .set_body_shift(Vector2::new(0.0, arm_length + space));
+        .set_parent_shift(Vector2::new(-body_radx - r!(2.0) * space, body_rady))
+        .set_body_shift(Vector2::new(r!(0.0), arm_length + space));
 
     /*
      * Legs.
      */
-    let leg_collider = ColliderDesc::new(leg_geom).density(0.3);
+    let leg_collider = ColliderDesc::new(leg_geom).density(r!(0.3));
     body.add_child(spherical)
         .set_parent_shift(Vector2::new(body_radx, -body_rady))
-        .set_body_shift(Vector2::new(0.0, leg_length + space));
+        .set_body_shift(Vector2::new(r!(0.0), leg_length + space));
 
     body.add_child(spherical)
         .set_parent_shift(Vector2::new(-body_radx, -body_rady))
-        .set_body_shift(Vector2::new(0.0, leg_length + space));
+        .set_body_shift(Vector2::new(r!(0.0), leg_length + space));
 
     let n = 5;
-    let shiftx = 2.0;
-    let shifty = 6.5;
+    let shiftx = r!(2.0);
+    let shifty = r!(6.5);
 
     for i in 0usize..n {
         for j in 0usize..n {
-            let x = i as f32 * shiftx - n as f32 * shiftx / 2.0;
-            let y = j as f32 * shifty + 6.0;
+            let x = r!(i as f64) * shiftx - r!(n as f64) * shiftx / r!(2.0);
+            let y = r!(j as f64) * shifty + r!(6.0);
 
             let free = FreeJoint::new(Isometry2::translation(x, y));
             let ragdoll = body.set_joint(free).build();
@@ -163,7 +180,7 @@ fn build_ragdolls(bodies: &mut DefaultBodySet<f32>, colliders: &mut DefaultColli
 }
 
 fn main() {
-    let mut testbed = Testbed::new_empty();
+    let mut testbed = Testbed::<f32>::new_empty();
     init_world(&mut testbed);
     testbed.run();
 }

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -13,9 +13,9 @@ rand       = { version = "0.7", features = [ "stdweb" ] }
 rand_distr = "0.2"
 num-traits = "0.2"
 Inflector  = "0.11"
-nalgebra   = "0.21"
-ncollide3d = "0.23"
-kiss3d     = "0.24"
+nalgebra   = "0.22"
+ncollide3d = "0.24"
+kiss3d     = "0.25"
 simba      = { version = "0.1", features = [ "partial_fixed_point_support" ]}
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -14,8 +14,8 @@ rand_distr = "0.2"
 num-traits = "0.2"
 Inflector  = "0.11"
 nalgebra   = "0.22"
-ncollide3d = "0.24"
-kiss3d     = "0.25"
+ncollide3d = "0.25"
+kiss3d     = "0.26"
 simba      = { version = "0.1", features = [ "partial_fixed_point_support" ]}
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/examples3d/broad_phase_filter3.rs
+++ b/examples3d/broad_phase_filter3.rs
@@ -10,13 +10,13 @@ use nphysics3d::object::{
     DefaultBodyHandle, DefaultBodySet, DefaultColliderHandle, DefaultColliderSet, Ground,
     MultibodyDesc,
 };
-use nphysics3d::world::{BroadPhaseCollisionSet, DefaultGeometricalWorld, DefaultMechanicalWorld};
+use nphysics3d::world::{BroadPhasePairFilterSets, DefaultGeometricalWorld, DefaultMechanicalWorld};
 
 use nphysics_testbed3d::Testbed;
 
 struct NoMultibodySelfContactFilter;
 
-impl<N, Bodies, Colliders> BroadPhasePairFilter<N, BroadPhaseCollisionSet<'_, N, Bodies, Colliders>>
+impl<N, Bodies, Colliders> BroadPhasePairFilter<N, BroadPhasePairFilterSets<'_, N, Bodies, Colliders>>
     for NoMultibodySelfContactFilter
 where
     N: RealField,
@@ -27,7 +27,7 @@ where
         &self,
         h1: Colliders::Handle,
         h2: Colliders::Handle,
-        set: &BroadPhaseCollisionSet<'_, N, Bodies, Colliders>,
+        set: &BroadPhasePairFilterSets<'_, N, Bodies, Colliders>,
     ) -> bool {
         let a1 = set.colliders().get(h1).map(|c| c.anchor());
         let a2 = set.colliders().get(h2).map(|c| c.anchor());

--- a/examples3d/broad_phase_filter3.rs
+++ b/examples3d/broad_phase_filter3.rs
@@ -1,64 +1,75 @@
 extern crate nalgebra as na;
 
-use na::{Isometry3, Point3, Vector3};
+use na::{Isometry3, Point3, RealField, Vector3};
 use ncollide3d::broad_phase::BroadPhasePairFilter;
 use ncollide3d::shape::{Ball, Capsule, Cuboid, ShapeHandle};
 use nphysics3d::force_generator::DefaultForceGeneratorSet;
 use nphysics3d::joint::{BallJoint, DefaultJointConstraintSet, FreeJoint};
 use nphysics3d::object::{
-    BodyPartHandle, Collider, ColliderAnchor, ColliderDesc, DefaultBodyHandle, DefaultBodySet,
-    DefaultColliderHandle, DefaultColliderSet, Ground, MultibodyDesc,
+    BodyPartHandle, BodySet, Collider, ColliderAnchor, ColliderDesc, ColliderSet,
+    DefaultBodyHandle, DefaultBodySet, DefaultColliderHandle, DefaultColliderSet, Ground,
+    MultibodyDesc,
 };
-use nphysics3d::world::{DefaultGeometricalWorld, DefaultMechanicalWorld};
+use nphysics3d::world::{BroadPhaseCollisionSet, DefaultGeometricalWorld, DefaultMechanicalWorld};
 
 use nphysics_testbed3d::Testbed;
 
 struct NoMultibodySelfContactFilter;
 
-impl BroadPhasePairFilter<f32, Collider<f32, DefaultBodyHandle>, DefaultColliderHandle>
+impl<N, Bodies, Colliders> BroadPhasePairFilter<N, BroadPhaseCollisionSet<'_, N, Bodies, Colliders>>
     for NoMultibodySelfContactFilter
+where
+    N: RealField,
+    Bodies: BodySet<N>,
+    Colliders: ColliderSet<N, Bodies::Handle>,
 {
     fn is_pair_valid(
         &self,
-        c1: &Collider<f32, DefaultBodyHandle>,
-        c2: &Collider<f32, DefaultBodyHandle>,
-        _: DefaultColliderHandle,
-        _: DefaultColliderHandle,
+        h1: Colliders::Handle,
+        h2: Colliders::Handle,
+        set: &BroadPhaseCollisionSet<'_, N, Bodies, Colliders>,
     ) -> bool {
-        match (c1.anchor(), c2.anchor()) {
+        let a1 = set.colliders().get(h1).map(|c| c.anchor());
+        let a2 = set.colliders().get(h2).map(|c| c.anchor());
+
+        match (a1, a2) {
             (
-                ColliderAnchor::OnBodyPart {
+                Some(ColliderAnchor::OnBodyPart {
                     body_part: part1, ..
-                },
-                ColliderAnchor::OnBodyPart {
+                }),
+                Some(ColliderAnchor::OnBodyPart {
                     body_part: part2, ..
-                },
+                }),
             ) => part1.0 != part2.0, // Don't collide if the two parts belong to the same body.
             _ => true,
         }
     }
 }
 
-pub fn init_world(testbed: &mut Testbed) {
+/*
+ * NOTE: The `r` macro is only here to convert from f64 to the `N` scalar type.
+ * This simplifies experimentation with various scalar types (f32, fixed-point numbers, etc.)
+ */
+pub fn init_world<N: RealField>(testbed: &mut Testbed<N>) {
     /*
      * World
      */
-    let mechanical_world = DefaultMechanicalWorld::new(Vector3::new(0.0, -9.81, 0.0));
-    let mut geometrical_world = DefaultGeometricalWorld::new();
+    let mechanical_world = DefaultMechanicalWorld::new(Vector3::new(r!(0.0), r!(-9.81), r!(0.0)));
+    let geometrical_world = DefaultGeometricalWorld::new();
     let mut bodies = DefaultBodySet::new();
     let mut colliders = DefaultColliderSet::new();
     let joint_constraints = DefaultJointConstraintSet::new();
     let force_generators = DefaultForceGeneratorSet::new();
 
-    // Setup the custom broad-phase pair filter to prevent contacts between
-    // links belonging to the same multibody.
-    geometrical_world.set_broad_phase_pair_filter(NoMultibodySelfContactFilter);
-
     /*
      * Ground.
      */
-    let ground_thickness = 0.2;
-    let ground_shape = ShapeHandle::new(Cuboid::new(Vector3::new(5.0, ground_thickness, 5.0)));
+    let ground_thickness = r!(0.2);
+    let ground_shape = ShapeHandle::new(Cuboid::new(Vector3::new(
+        r!(5.0),
+        ground_thickness,
+        r!(5.0),
+    )));
 
     let ground_handle = bodies.insert(Ground::new());
     let co = ColliderDesc::new(ground_shape)
@@ -75,6 +86,7 @@ pub fn init_world(testbed: &mut Testbed) {
      * Set up the testbed.
      */
     testbed.set_ground_handle(Some(ground_handle));
+    testbed.set_broad_phase_pair_filter(NoMultibodySelfContactFilter);
     testbed.set_world(
         mechanical_world,
         geometrical_world,
@@ -86,15 +98,18 @@ pub fn init_world(testbed: &mut Testbed) {
     testbed.look_at(Point3::new(-10.0, 5.0, -10.0), Point3::new(0.0, 1.0, 0.0));
 }
 
-fn build_ragdolls(bodies: &mut DefaultBodySet<f32>, colliders: &mut DefaultColliderSet<f32>) {
-    let body_rady = 1.2 / 2.0;
-    let body_radz = 0.4 / 2.0;
-    let body_radx = 0.2 / 2.0;
-    let head_rad = 0.4 / 2.0;
-    let member_rad = 0.15 / 2.0;
-    let arm_length = 0.9 / 2.0;
-    let leg_length = 1.4 / 2.0;
-    let space = 0.15;
+fn build_ragdolls<N: RealField>(
+    bodies: &mut DefaultBodySet<N>,
+    colliders: &mut DefaultColliderSet<N>,
+) {
+    let body_rady = r!(1.2) / r!(2.0);
+    let body_radz = r!(0.4) / r!(2.0);
+    let body_radx = r!(0.2) / r!(2.0);
+    let head_rad = r!(0.4) / r!(2.0);
+    let member_rad = r!(0.15) / r!(2.0);
+    let arm_length = r!(0.9) / r!(2.0);
+    let leg_length = r!(1.4) / r!(2.0);
+    let space = r!(0.15);
 
     let body_geom = ShapeHandle::new(Cuboid::new(Vector3::new(body_radx, body_rady, body_radz)));
     let head_geom = ShapeHandle::new(Ball::new(head_rad));
@@ -110,53 +125,61 @@ fn build_ragdolls(bodies: &mut DefaultBodySet<f32>, colliders: &mut DefaultColli
     /*
      * Body.
      */
-    let body_collider = ColliderDesc::new(body_geom).density(0.3);
+    let body_collider = ColliderDesc::new(body_geom).density(r!(0.3));
     let mut body = MultibodyDesc::new(free);
 
     /*
      * Head.
      */
-    let head_collider = ColliderDesc::new(head_geom).density(0.3);
+    let head_collider = ColliderDesc::new(head_geom).density(r!(0.3));
     body.add_child(spherical).set_parent_shift(Vector3::new(
-        0.0,
+        r!(0.0),
         body_rady + head_rad + space,
-        0.0,
+        r!(0.0),
     ));
 
     /*
      * Arms.
      */
-    let arm_collider = ColliderDesc::new(arm_geom).density(0.3);
+    let arm_collider = ColliderDesc::new(arm_geom).density(r!(0.3));
     body.add_child(spherical)
-        .set_parent_shift(Vector3::new(0.0, body_rady, body_radx + 2.0 * space))
-        .set_body_shift(Vector3::new(0.0, arm_length + space, 0.0));
+        .set_parent_shift(Vector3::new(
+            r!(0.0),
+            body_rady,
+            body_radx + r!(2.0) * space,
+        ))
+        .set_body_shift(Vector3::new(r!(0.0), arm_length + space, r!(0.0)));
 
     body.add_child(spherical)
-        .set_parent_shift(Vector3::new(0.0, body_rady, -body_radx - 2.0 * space))
-        .set_body_shift(Vector3::new(0.0, arm_length + space, 0.0));
+        .set_parent_shift(Vector3::new(
+            r!(0.0),
+            body_rady,
+            -body_radx - r!(2.0) * space,
+        ))
+        .set_body_shift(Vector3::new(r!(0.0), arm_length + space, r!(0.0)));
 
     /*
      * Legs.
      */
-    let leg_collider = ColliderDesc::new(leg_geom).density(0.3);
+    let leg_collider = ColliderDesc::new(leg_geom).density(r!(0.3));
     body.add_child(spherical)
-        .set_parent_shift(Vector3::new(0.0, -body_rady, body_radx))
-        .set_body_shift(Vector3::new(0.0, leg_length + space, 0.0));
+        .set_parent_shift(Vector3::new(r!(0.0), -body_rady, body_radx))
+        .set_body_shift(Vector3::new(r!(0.0), leg_length + space, r!(0.0)));
 
     body.add_child(spherical)
-        .set_parent_shift(Vector3::new(0.0, -body_rady, -body_radx))
-        .set_body_shift(Vector3::new(0.0, leg_length + space, 0.0));
+        .set_parent_shift(Vector3::new(r!(0.0), -body_rady, -body_radx))
+        .set_body_shift(Vector3::new(r!(0.0), leg_length + space, r!(0.0)));
 
     let n = 3;
-    let shift = 1.0;
-    let shifty = 5.0;
+    let shift = r!(1.0);
+    let shifty = r!(5.0);
 
     for i in 0usize..n {
         for j in 0usize..n {
             for k in 0usize..n {
-                let x = i as f32 * shift - n as f32 * shift / 2.0;
-                let y = j as f32 * shifty + 3.0;
-                let z = k as f32 * shift - n as f32 * shift / 2.0;
+                let x = r!(i as f64) * shift - r!(n as f64) * shift / r!(2.0);
+                let y = r!(j as f64) * shifty + r!(3.0);
+                let z = r!(k as f64) * shift - r!(n as f64) * shift / r!(2.0);
 
                 let free = FreeJoint::new(Isometry3::translation(x, y, z));
                 let ragdoll = body.set_joint(free).build();
@@ -174,6 +197,6 @@ fn build_ragdolls(bodies: &mut DefaultBodySet<f32>, colliders: &mut DefaultColli
 }
 
 fn main() {
-    let testbed = Testbed::from_builders(0, vec![("Ragdolls", init_world)]);
+    let testbed = Testbed::<f32>::from_builders(0, vec![("Broad-phase filter", init_world)]);
     testbed.run()
 }

--- a/src/joint/prismatic_joint.rs
+++ b/src/joint/prismatic_joint.rs
@@ -118,13 +118,13 @@ impl<N: RealField> PrismaticJoint<N> {
         self.motor.desired_velocity = vel;
     }
 
-    /// The max angular velocity that the joint motor will attempt.
-    pub fn max_angular_motor_velocity(&self) -> N {
+    /// The max linear velocity that the joint motor will attempt.
+    pub fn max_linear_motor_velocity(&self) -> N {
         self.motor.max_velocity
     }
 
-    /// Set the maximum angular velocity that the joint motor will attempt.
-    pub fn set_max_angular_motor_velocity(&mut self, max_vel: N) {
+    /// Set the maximum linear velocity that the joint motor will attempt.
+    pub fn set_max_linear_motor_velocity(&mut self, max_vel: N) {
         self.motor.max_velocity = max_vel;
     }
 

--- a/src/world/geometrical_world.rs
+++ b/src/world/geometrical_world.rs
@@ -285,7 +285,7 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
     pub fn perform_broad_phase<Colliders, Filter>(
         &mut self,
         colliders: &Colliders,
-        user_filter: Filter,
+        user_filter: &Filter,
     ) where
         Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
         Filter: BroadPhasePairFilter<N, Colliders>,
@@ -856,14 +856,14 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
     }
 }
 
-pub struct BroadPhaseCollisionSet<'a, N, Bodies, CollSet>
+pub struct BroadPhaseCollisionSet<'a, N, Bodies, Colliders>
 where
     N: RealField,
     Bodies: BodySet<N>,
-    CollSet: ColliderSet<N, Bodies::Handle>,
+    Colliders: ColliderSet<N, Bodies::Handle>,
 {
     /// The set of colliders within the simulation.
-    colliders: &'a CollSet,
+    colliders: &'a Colliders,
 
     /// The set of bodies within the simulation.
     bodies: &'a Bodies,
@@ -872,11 +872,11 @@ where
     _pd: PhantomData<N>,
 }
 
-impl<'a, N, Bodies, CollSet> BroadPhaseCollisionSet<'a, N, Bodies, CollSet>
+impl<'a, N, Bodies, Colliders> BroadPhaseCollisionSet<'a, N, Bodies, Colliders>
 where
     N: RealField,
     Bodies: BodySet<N>,
-    CollSet: ColliderSet<N, Bodies::Handle>,
+    Colliders: ColliderSet<N, Bodies::Handle>,
 {
     /// Returns the body set used in the physics step.
     pub fn body_set(&self) -> &Bodies {
@@ -884,20 +884,20 @@ where
     }
 
     /// Returns the collider set used in the physics step.
-    pub fn colliders(&self) -> &CollSet {
+    pub fn colliders(&self) -> &Colliders {
         self.colliders
     }
 }
 
-impl<'a, N, Bodies, CollSet> CollisionObjectSet<N>
-    for BroadPhaseCollisionSet<'a, N, Bodies, CollSet>
+impl<'a, N, Bodies, Colliders> CollisionObjectSet<N>
+    for BroadPhaseCollisionSet<'a, N, Bodies, Colliders>
 where
     N: RealField,
     Bodies: BodySet<N>,
-    CollSet: ColliderSet<N, Bodies::Handle>,
+    Colliders: ColliderSet<N, Bodies::Handle>,
 {
     type CollisionObject = Collider<N, Bodies::Handle>;
-    type CollisionObjectHandle = CollSet::Handle;
+    type CollisionObjectHandle = Colliders::Handle;
 
     fn collision_object(
         &self,
@@ -911,8 +911,8 @@ where
     }
 }
 
-struct DefaultCollisionFilter<Filter, Handle> {
-    user_filter: Filter,
+struct DefaultCollisionFilter<'a, Filter, Handle> {
+    user_filter: &'a Filter,
 
     /// Makes the compiler happy.
     _pd: PhantomData<Handle>,

--- a/src/world/geometrical_world.rs
+++ b/src/world/geometrical_world.rs
@@ -5,9 +5,9 @@ use na::RealField;
 
 use ncollide::bounding_volume::AABB;
 use ncollide::pipeline::{
-    self, BroadPhase, BroadPhasePairFilter, CollisionGroups, CollisionObjectSet, ContactAlgorithm, ContactEvents,
-    DBVTBroadPhase, DefaultContactDispatcher, DefaultProximityDispatcher, Interaction,
-    InteractionGraph, NarrowPhase, ProximityDetector, ProximityEvents,
+    self, BroadPhase, BroadPhasePairFilter, CollisionGroups, CollisionObjectSet, ContactAlgorithm,
+    ContactEvents, DBVTBroadPhase, DefaultContactDispatcher, DefaultProximityDispatcher,
+    Interaction, InteractionGraph, NarrowPhase, ProximityDetector, ProximityEvents,
 };
 use ncollide::query::{ContactManifold, Proximity, Ray};
 
@@ -284,15 +284,16 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
     /// Executes the broad phase of the collision detection pipeline.
     pub fn perform_broad_phase<Colliders, Filter>(
         &mut self,
-        colliders:
-        &Colliders,
+        colliders: &Colliders,
         user_filter: Filter,
-    )
-    where
+    ) where
         Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
         Filter: BroadPhasePairFilter<N, Colliders>,
     {
-        let pair_filter = DefaultCollisionFilter { user_filter, _pd: PhantomData };
+        let pair_filter = DefaultCollisionFilter {
+            user_filter,
+            _pd: PhantomData,
+        };
 
         pipeline::perform_broad_phase(
             colliders,
@@ -888,7 +889,8 @@ where
     }
 }
 
-impl<'a, N, Bodies, CollSet> CollisionObjectSet<N> for BroadPhaseCollisionSet<'a, N, Bodies, CollSet>
+impl<'a, N, Bodies, CollSet> CollisionObjectSet<N>
+    for BroadPhaseCollisionSet<'a, N, Bodies, CollSet>
 where
     N: RealField,
     Bodies: BodySet<N>,
@@ -897,7 +899,10 @@ where
     type CollisionObject = Collider<N, Bodies::Handle>;
     type CollisionObjectHandle = CollSet::Handle;
 
-    fn collision_object(&self, handle: Self::CollisionObjectHandle) -> Option<&Self::CollisionObject> {
+    fn collision_object(
+        &self,
+        handle: Self::CollisionObjectHandle,
+    ) -> Option<&Self::CollisionObject> {
         self.colliders.get(handle)
     }
 
@@ -906,27 +911,22 @@ where
     }
 }
 
-struct DefaultCollisionFilter<Filter, Handle>
-{
+struct DefaultCollisionFilter<Filter, Handle> {
     user_filter: Filter,
 
     /// Makes the compiler happy.
     _pd: PhantomData<Handle>,
 }
 
-impl<'a, N, Handle, Set, Filter> BroadPhasePairFilter<N, Set> for DefaultCollisionFilter<Filter, Handle>
+impl<'a, N, Handle, Set, Filter> BroadPhasePairFilter<N, Set>
+    for DefaultCollisionFilter<Filter, Handle>
 where
     N: RealField,
     Handle: BodyHandle,
     Set: ColliderSet<N, Handle>,
     Filter: BroadPhasePairFilter<N, Set>,
 {
-    fn is_pair_valid(
-        &self,
-        h1: Set::Handle,
-        h2: Set::Handle,
-        set: &Set,
-    ) -> bool {
+    fn is_pair_valid(&self, h1: Set::Handle, h2: Set::Handle, set: &Set) -> bool {
         let (c1, c2) = match (set.get(h1), set.get(h2)) {
             (Some(c1), Some(c2)) => (c1, c2),
             _ => return false,

--- a/src/world/geometrical_world.rs
+++ b/src/world/geometrical_world.rs
@@ -13,7 +13,7 @@ use ncollide::query::{ContactManifold, Proximity, Ray};
 
 use crate::object::{
     BodyHandle, BodySet, Collider, ColliderAnchor, ColliderHandle, ColliderSet, DefaultBodyHandle,
-    DefaultColliderHandle,
+    DefaultBodySet, DefaultColliderHandle, DefaultColliderSet,
 };
 use crate::volumetric::Volumetric;
 
@@ -290,7 +290,7 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
     ) where
         Bodies: BodySet<N, Handle = Handle>,
         Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
-        Filter: for<'a> BroadPhasePairFilter<N, BroadPhaseCollisionSet<'a, N, Bodies, Colliders>>
+        Filter: for<'a> BroadPhasePairFilter<N, BroadPhasePairFilterSets<'a, N, Bodies, Colliders>>
             + ?Sized,
     {
         let pair_filter = DefaultCollisionFilter {
@@ -299,7 +299,7 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
         };
 
         pipeline::perform_broad_phase(
-            &BroadPhaseCollisionSet {
+            &BroadPhasePairFilterSets {
                 bodies,
                 colliders,
                 _pd: PhantomData,
@@ -863,8 +863,11 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
     }
 }
 
+/// The default set of bodies and colliders used within broad phase collision filtering.
+pub type DefaultBroadPhasePairFilterSets<'a, N> = BroadPhasePairFilterSets<'a, N, DefaultBodySet<N>, DefaultColliderSet<N>>;
+
 /// The set of bodies and colliders used within broad phase collision filtering.
-pub struct BroadPhaseCollisionSet<'a, N, Bodies, Colliders>
+pub struct BroadPhasePairFilterSets<'a, N, Bodies, Colliders>
 where
     N: RealField,
     Bodies: BodySet<N>,
@@ -880,7 +883,7 @@ where
     _pd: PhantomData<N>,
 }
 
-impl<'a, N, Bodies, Colliders> BroadPhaseCollisionSet<'a, N, Bodies, Colliders>
+impl<'a, N, Bodies, Colliders> BroadPhasePairFilterSets<'a, N, Bodies, Colliders>
 where
     N: RealField,
     Bodies: BodySet<N>,
@@ -898,7 +901,7 @@ where
 }
 
 impl<'a, N, Bodies, Colliders> CollisionObjectSet<N>
-    for BroadPhaseCollisionSet<'a, N, Bodies, Colliders>
+    for BroadPhasePairFilterSets<'a, N, Bodies, Colliders>
 where
     N: RealField,
     Bodies: BodySet<N>,

--- a/src/world/mechanical_world.rs
+++ b/src/world/mechanical_world.rs
@@ -18,7 +18,7 @@ use crate::object::{
     DefaultBodyHandle, DefaultColliderHandle,
 };
 use crate::solver::{IntegrationParameters, MoreauJeanSolver, SignoriniCoulombPyramidModel};
-use crate::world::{BroadPhaseCollisionSet, GeometricalWorld};
+use crate::world::{BroadPhasePairFilterSets, GeometricalWorld};
 
 /// The default mechanical world, that can be used with a `DefaultBodyHandle` and `DefaultColliderHandle`.
 pub type DefaultMechanicalWorld<N> = MechanicalWorld<N, DefaultBodyHandle, DefaultColliderHandle>;
@@ -209,7 +209,7 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
         Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
         Constraints: JointConstraintSet<N, Handle>,
         Forces: ForceGeneratorSet<N, Handle>,
-        Filter: for<'a> BroadPhasePairFilter<N, BroadPhaseCollisionSet<'a, N, Bodies, Colliders>>
+        Filter: for<'a> BroadPhasePairFilter<N, BroadPhasePairFilterSets<'a, N, Bodies, Colliders>>
             + ?Sized,
     {
         if !self.substep.active {
@@ -571,7 +571,7 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
         Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
         Constraints: JointConstraintSet<N, Handle>,
         Forces: ForceGeneratorSet<N, Handle>,
-        Filter: for<'a> BroadPhasePairFilter<N, BroadPhaseCollisionSet<'a, N, Bodies, Colliders>>
+        Filter: for<'a> BroadPhasePairFilter<N, BroadPhasePairFilterSets<'a, N, Bodies, Colliders>>
             + ?Sized,
     {
         let dt0 = self.integration_parameters.dt();

--- a/src/world/mechanical_world.rs
+++ b/src/world/mechanical_world.rs
@@ -18,7 +18,7 @@ use crate::object::{
     DefaultBodyHandle, DefaultColliderHandle,
 };
 use crate::solver::{IntegrationParameters, MoreauJeanSolver, SignoriniCoulombPyramidModel};
-use crate::world::GeometricalWorld;
+use crate::world::{BroadPhaseCollisionSet, GeometricalWorld};
 
 /// The default mechanical world, that can be used with a `DefaultBodyHandle` and `DefaultColliderHandle`.
 pub type DefaultMechanicalWorld<N> = MechanicalWorld<N, DefaultBodyHandle, DefaultColliderHandle>;
@@ -179,14 +179,15 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
     }
 
     /// Execute one time step of the physics simulation.
-    pub fn step<Colliders, Constraints, Forces>(
+    pub fn step<Bodies, Colliders, Constraints, Forces>(
         &mut self,
         gworld: &mut GeometricalWorld<N, Handle, CollHandle>,
-        bodies: &mut dyn BodySet<N, Handle = Handle>,
+        bodies: &mut Bodies,
         colliders: &mut Colliders,
         constraints: &mut Constraints,
         forces: &mut Forces,
     ) where
+        Bodies: BodySet<N, Handle = Handle>,
         Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
         Constraints: JointConstraintSet<N, Handle>,
         Forces: ForceGeneratorSet<N, Handle>,
@@ -195,19 +196,21 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
     }
 
     /// Execute one time step of the physics simulation.
-    pub fn step_with_filter<Colliders, Constraints, Forces, Filter>(
+    pub fn step_with_filter<Bodies, Colliders, Constraints, Forces, Filter>(
         &mut self,
         gworld: &mut GeometricalWorld<N, Handle, CollHandle>,
-        bodies: &mut dyn BodySet<N, Handle = Handle>,
+        bodies: &mut Bodies,
         colliders: &mut Colliders,
         constraints: &mut Constraints,
         forces: &mut Forces,
         filter: &Filter,
     ) where
+        Bodies: BodySet<N, Handle = Handle>,
         Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
         Constraints: JointConstraintSet<N, Handle>,
         Forces: ForceGeneratorSet<N, Handle>,
-        Filter: BroadPhasePairFilter<N, Colliders>,
+        Filter: for<'a> BroadPhasePairFilter<N, BroadPhaseCollisionSet<'a, N, Bodies, Colliders>>
+            + ?Sized,
     {
         if !self.substep.active {
             self.counters.step_started();
@@ -246,7 +249,7 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
              */
             gworld.clear_events();
             gworld.sync_colliders(bodies, colliders);
-            gworld.perform_broad_phase(colliders, filter);
+            gworld.perform_broad_phase(bodies, colliders, filter);
             gworld.perform_narrow_phase(colliders);
 
             colliders.foreach_mut(|_, c| c.clear_update_flags());
@@ -373,7 +376,7 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
             gworld.sync_colliders(bodies, colliders);
 
             self.counters.broad_phase_started();
-            gworld.perform_broad_phase(colliders, filter);
+            gworld.perform_broad_phase(bodies, colliders, filter);
             self.counters.broad_phase_completed();
 
             self.counters.narrow_phase_started();
@@ -555,19 +558,21 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
         PredictedImpacts::Impacts(impacts, frozen)
     }
 
-    fn solve_ccd<Colliders, Constraints, Forces, Filter>(
+    fn solve_ccd<Bodies, Colliders, Constraints, Forces, Filter>(
         &mut self,
         gworld: &mut GeometricalWorld<N, Handle, CollHandle>,
-        bodies: &mut dyn BodySet<N, Handle = Handle>,
+        bodies: &mut Bodies,
         colliders: &mut Colliders,
         constraints: &mut Constraints,
         _forces: &mut Forces,
-        filter: Filter,
+        filter: &Filter,
     ) where
+        Bodies: BodySet<N, Handle = Handle>,
         Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
         Constraints: JointConstraintSet<N, Handle>,
         Forces: ForceGeneratorSet<N, Handle>,
-        Filter: BroadPhasePairFilter<N, Colliders> + Copy,
+        Filter: for<'a> BroadPhasePairFilter<N, BroadPhaseCollisionSet<'a, N, Bodies, Colliders>>
+            + ?Sized,
     {
         let dt0 = self.integration_parameters.dt();
         let _inv_dt0 = self.integration_parameters.inv_dt();
@@ -598,7 +603,7 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
             // Update the broad phase.
             self.counters.ccd.broad_phase_time.resume();
             gworld.sync_colliders(bodies, colliders);
-            gworld.perform_broad_phase(colliders, filter);
+            gworld.perform_broad_phase(bodies, colliders, filter);
             self.counters.ccd.broad_phase_time.pause();
 
             // Compute the next TOI.

--- a/src/world/mechanical_world.rs
+++ b/src/world/mechanical_world.rs
@@ -191,7 +191,7 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
         Constraints: JointConstraintSet<N, Handle>,
         Forces: ForceGeneratorSet<N, Handle>,
     {
-        self.step_with_filter(gworld, bodies, colliders, constraints, forces, ())
+        self.step_with_filter(gworld, bodies, colliders, constraints, forces, &())
     }
 
     /// Execute one time step of the physics simulation.
@@ -202,12 +202,12 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
         colliders: &mut Colliders,
         constraints: &mut Constraints,
         forces: &mut Forces,
-        filter: Filter,
+        filter: &Filter,
     ) where
         Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
         Constraints: JointConstraintSet<N, Handle>,
         Forces: ForceGeneratorSet<N, Handle>,
-        Filter: BroadPhasePairFilter<N, Colliders> + Copy,
+        Filter: BroadPhasePairFilter<N, Colliders>,
     {
         if !self.substep.active {
             self.counters.step_started();

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1,6 +1,8 @@
 //! The physics world.
 
-pub use self::geometrical_world::{DefaultGeometricalWorld, GeometricalWorld};
+pub use self::geometrical_world::{
+    BroadPhaseCollisionSet, DefaultGeometricalWorld, GeometricalWorld,
+};
 pub use self::mechanical_world::{DefaultMechanicalWorld, MechanicalWorld};
 
 mod geometrical_world;

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1,7 +1,7 @@
 //! The physics world.
 
 pub use self::geometrical_world::{
-    BroadPhaseCollisionSet, DefaultGeometricalWorld, GeometricalWorld,
+    BroadPhasePairFilterSets, DefaultBroadPhasePairFilterSets, DefaultGeometricalWorld, GeometricalWorld,
 };
 pub use self::mechanical_world::{DefaultMechanicalWorld, MechanicalWorld};
 

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -37,7 +37,7 @@ use nphysics::object::{
     ActivationStatus, BodyPartHandle, DefaultBodyHandle, DefaultBodyPartHandle, DefaultBodySet,
     DefaultColliderHandle, DefaultColliderSet,
 };
-use nphysics::world::{BroadPhaseCollisionSet, DefaultGeometricalWorld, DefaultMechanicalWorld};
+use nphysics::world::{DefaultBroadPhasePairFilterSets, DefaultGeometricalWorld, DefaultMechanicalWorld};
 #[cfg(feature = "fluids")]
 use salva::{coupling::ColliderCouplingSet, object::FluidHandle, LiquidWorld};
 
@@ -134,7 +134,7 @@ pub struct Testbed<N: RealField = f32> {
     colliders: DefaultColliderSet<N>,
     forces: DefaultForceGeneratorSet<N>,
     constraints: DefaultJointConstraintSet<N>,
-    broad_phase_filter: Box<dyn for<'a> BroadPhasePairFilter<N, CollisionSet<'a, N>>>,
+    broad_phase_filter: Box<dyn for<'a> BroadPhasePairFilter<N, DefaultBroadPhasePairFilterSets<'a, N>>>,
     window: Option<Box<Window>>,
     graphics: GraphicsManager,
     nsteps: usize,
@@ -153,8 +153,6 @@ pub struct Testbed<N: RealField = f32> {
     #[cfg(feature = "box2d-backend")]
     box2d: Option<Box2dWorld>,
 }
-
-type CollisionSet<'a, N> = BroadPhaseCollisionSet<'a, N, DefaultBodySet<N>, DefaultColliderSet<N>>;
 
 type Callbacks<N> = Vec<
     Box<
@@ -361,7 +359,7 @@ impl<N: RealField> Testbed<N> {
 
     pub fn set_broad_phase_pair_filter<F>(&mut self, filter: F)
     where
-        for<'a> F: BroadPhasePairFilter<N, CollisionSet<'a, N>>,
+        for<'a> F: BroadPhasePairFilter<N, DefaultBroadPhasePairFilterSets<'a, N>>,
         F: 'static,
     {
         self.broad_phase_filter = Box::new(filter);

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -22,7 +22,7 @@ use kiss3d::window::{State, Window};
 #[cfg(feature = "dim2")]
 use na::Vector2;
 use na::{self, Point2, Point3, RealField, Vector3};
-use ncollide::pipeline::CollisionGroups;
+use ncollide::pipeline::{BroadPhasePairFilter, CollisionGroups};
 #[cfg(feature = "dim3")]
 use ncollide::query;
 use ncollide::query::{ContactId, Ray};
@@ -134,6 +134,7 @@ pub struct Testbed<N: RealField = f32> {
     colliders: DefaultColliderSet<N>,
     forces: DefaultForceGeneratorSet<N>,
     constraints: DefaultJointConstraintSet<N>,
+    broad_phase_filter: Box<dyn BroadPhasePairFilter<N, DefaultColliderSet<N>> + Copy>,
     window: Option<Box<Window>>,
     graphics: GraphicsManager,
     nsteps: usize,
@@ -236,6 +237,7 @@ impl<N: RealField> Testbed<N> {
             colliders,
             forces,
             constraints,
+            broad_phase_filter: (),
             callbacks: Vec::new(),
             #[cfg(feature = "fluids")]
             callbacks_fluids: Vec::new(),


### PR DESCRIPTION
Meant to be paired with [ncollide#359](https://github.com/dimforge/ncollide/pull/359).

This utilizes the new formulation of the `BroadPhasePairFilter` trait to supply both the `BodySet` and `ColliderSet` to the broad phase pair filter. This allows for the filter to take into account information that exists in the body, such as multibody link ancestry, velocity, etc.

From the user's perspective, this removes `GeometricalWorld::set_broad_phase_pair_filter` and provides a `MechanicalWorld::step_with_filter(.., impl BroadPhasePairFilter)` where the filter has access to the body set.